### PR TITLE
test with specific internals for cmp issue

### DIFF
--- a/decimal_test.go
+++ b/decimal_test.go
@@ -3,6 +3,7 @@ package decimal
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"testing"
@@ -723,5 +724,13 @@ func TestBig_Sub(t *testing.T) {
 		if cs := c.String(); cs != inp.r {
 			t.Errorf("#%d: wanted %s, got %s", i, inp.r, cs)
 		}
+	}
+}
+
+func TestBig_CmpUnscale(t *testing.T) {
+	b1 := &Big{compact: 9223372036854775807, scale: 5, ctx: Context{precision: 0, mode: RoundingMode(0)}, form: 1, unscaled: *new(big.Int).SetInt64(181050000)}
+	b2 := &Big{compact: 18105, scale: 1, ctx: Context{precision: 0, mode: RoundingMode(0)}, form: 1, unscaled: *new(big.Int).SetInt64(0)}
+	if b1.Cmp(b2) != 0 {
+		t.Errorf("failed comparing %v with %v: %v", b1, b2, b1.Cmp(b2))
 	}
 }


### PR DESCRIPTION
```
--- FAIL: TestBig_Cmp (0.00s)
	decimal_test.go:170: #10: wanted 0, got -1
--- FAIL: TestBig_IsBig (0.00s)
	decimal_test.go:191: #4: wanted true, got false
--- FAIL: TestBig_CmpUnscale (0.00s)
	decimal_test.go:569: failed comparing 1810.5 with 1810.5: 1
```