### PR TITLE
Add gopkg.in/inf.v0 for benchmark comparison

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,16 +10,17 @@
 |-------------------------------------------|----------|-------------|-----------|------------|---------|
 | [JDK BigDecimal][4] (Java 1.8, warm)           | 0.049    | 0.19        | 0.6       | 3.29       | 1.05    |
 | [ericlagergren/decimal][1] (Go 1.9, mode Go)   | 0.034    | 0.40        | 1.00      | 3.57       | 1.25    |
+| [go-inf/inf][8] (Go 1.9)                       | 0.075    | 0.16        | 0.34      | 1.06       | 0.41    |
 | [Python decimal][5] (Python 3.6.2)             | 0.27     | 0.58        | 1.32      | 4.52       | 1.67    |
 | [ericlagergren/decimal][1] (Go 1.9, mode GDA)  | 0.048    | 0.55        | 1.46      | 4.91       | 1.74    |
 | [JDK BigDecimal][4] (Java 1.8)                 | 0.29     | 0.96        | 1.79      | 3.99       | 1.76    |
 | [shopspring/decimal][7] decimal (Go 1.9)       | 0.38     | 0.94        | 1.95      | 5.26       | 2.13    |
 | [cockroachdb/apd][2] (Go 1.9)                  | 0.52     | 2.14        | 9.01      | 71.62      | 20.81   |
 | [Python decimal][6] (Python 2.7.10)            | 12.93    | 28.91       | 64.96     | 192.58     | 74.84   |
-| float64 (Go 1.9)                          | 0.057    | -           | -         | -          | -       |
-| double (C LLVM 9.0.0 -O3)                 | 0.057    | -           | -         | -          | -       |
+| float64 (Go 1.9)                               | 0.057    | -           | -         | -          | -       |
+| double (C LLVM 9.0.0 -O3)                      | 0.057    | -           | -         | -          | -       |
 | [apmckinlay/dnum][3] (Go 1.9)                  | 0.091    | -           | -         | -          | -       |
-| float (Python 2.7.10)                     | 0.59     | -           | -         | -          | -       |
+| float (Python 2.7.10)                          | 0.59     | -           | -         | -          | -       |
 
 [1]: https://github.com/ericlagergren/decimal
 [2]: https://github.com/cockroachdb/apd
@@ -28,3 +29,4 @@
 [5]: https://docs.python.org/3.6/library/decimal.html
 [6]: https://docs.python.org/2/library/decimal.html
 [7]: https://github.com/shopspring/decimal
+[8]: https://github.com/go-inf/inf


### PR DESCRIPTION
Bit faster than decimal in case >18 digits in PI. inf has high initial allocation costs.

```
goos: darwin
goarch: amd64
pkg: github.com/ericlagergren/decimal/benchmarks
BenchmarkPi_decimal_Go_9-4     	      30	  41574158 ns/op	 6720006 B/op	   70000 allocs/op
BenchmarkPi_decimal_Go_19-4    	       3	 465468668 ns/op	171520032 B/op	 3950000 allocs/op
BenchmarkPi_decimal_Go_38-4    	       1	1172683254 ns/op	421842192 B/op	 9080885 allocs/op
BenchmarkPi_decimal_Go_100-4   	       1	4205209252 ns/op	1510736184 B/op	26403268 allocs/op
BenchmarkPi_inf_9-4            	      20	  80067259 ns/op	39880076 B/op	  950000 allocs/op
BenchmarkPi_inf_19-4           	      10	 164385987 ns/op	76480150 B/op	 1850000 allocs/op
BenchmarkPi_inf_38-4           	       3	 337969916 ns/op	152600309 B/op	 3710000 allocs/op
BenchmarkPi_inf_100-4          	       1	1068472434 ns/op	458600928 B/op	10040001 allocs/op
```