### PR TITLE
support compilation with Gopherjs

### DIFF
--- a/internal/c/const32.go
+++ b/internal/c/const32.go
@@ -1,4 +1,4 @@
-// +build 386 mips mipsle arm
+// +build js 386 mips mipsle arm
 
 package c
 


### PR DESCRIPTION
We hit a problem trying to compile this `decimal` library to Javascript and this little additional build tag fixes it. 
Thank you! 