### PR TITLE
Enable long-running dectests

### DIFF
--- a/dectest/skip.go
+++ b/dectest/skip.go
@@ -208,8 +208,9 @@ var skip = map[string]struct{}{
 	/* disagreement for three arg power */
 	"pwmx325": {},
 	"pwmx326": {},
+}
 
-	// The following cases are skipped because they cause the test runner to hang:
+var longRunning = map[string]struct{}{
 	"dvix338":  {},
 	"dvix337":  {},
 	"dvix330":  {},

--- a/dectest/test.go
+++ b/dectest/test.go
@@ -22,6 +22,11 @@ func Test(t *testing.T, file string) {
 		if !isSupported(c) {
 			continue
 		}
+		if testing.Short() {
+			if _, ok := longRunning[c.ID]; ok {
+				continue
+			}
+		}
 		execute(t, c)
 	}
 	if err := s.Err(); err != nil {


### PR DESCRIPTION
This PR enables a number of dectests I had previously incorrectly skipped. It turns out they're just very long running (due to modular exponentiation).