### PR TITLE
Make examples more realistic by importing the decimal package

### DIFF
--- a/example_calculator_test.go
+++ b/example_calculator_test.go
@@ -1,14 +1,16 @@
-package decimal
+package decimal_test
 
 import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/ericlagergren/decimal"
 )
 
 func ExampleBig_reversePolishNotationCalculator() {
 	const input = "15 7 1 1 + - / 3 * 2 1 1 + + - 5 * 3 / ="
-	var stack []*Big
+	var stack []*decimal.Big
 Loop:
 	for _, tok := range strings.Split(input, " ") {
 		last := len(stack) - 1
@@ -32,7 +34,7 @@ Loop:
 		case "=":
 			break Loop
 		default:
-			x := WithContext(Context128)
+			x := decimal.WithContext(decimal.Context128)
 			if _, ok := x.SetString(tok); !ok {
 				fmt.Fprintf(os.Stderr, "invalid decimal: %v\n", x.Context.Err())
 				os.Exit(1)

--- a/example_decimal_test.go
+++ b/example_decimal_test.go
@@ -1,12 +1,14 @@
-package decimal
+package decimal_test
 
 import (
 	"fmt"
+
+	"github.com/ericlagergren/decimal"
 )
 
 func ExampleBig_Format() {
 	print := func(format, xs string) {
-		x, _ := new(Big).SetString(xs)
+		x, _ := new(decimal.Big).SetString(xs)
 		fmt.Printf(format+"\n", x)
 	}
 
@@ -24,10 +26,10 @@ func ExampleBig_Format() {
 }
 
 func ExampleBig_Precision() {
-	a := New(12, 0)
-	b := New(42, -2)
-	c := New(12345, 3)
-	d := New(3, 5)
+	a := decimal.New(12, 0)
+	b := decimal.New(42, -2)
+	c := decimal.New(12345, 3)
+	d := decimal.New(3, 5)
 
 	fmt.Printf(`
 %s has a precision of %d
@@ -44,10 +46,10 @@ func ExampleBig_Precision() {
 }
 
 func ExampleBig_Round() {
-	a, _ := new(Big).SetString("1234")
-	b, _ := new(Big).SetString("54.4")
-	c, _ := new(Big).SetString("60")
-	d, _ := new(Big).SetString("0.0022")
+	a, _ := new(decimal.Big).SetString("1234")
+	b, _ := new(decimal.Big).SetString("54.4")
+	c, _ := new(decimal.Big).SetString("60")
+	d, _ := new(decimal.Big).SetString("0.0022")
 
 	fmt.Println(a.Round(2))
 	fmt.Println(b.Round(2))
@@ -61,10 +63,10 @@ func ExampleBig_Round() {
 }
 
 func ExampleBig_Quantize() {
-	a, _ := WithContext(Context32).SetString("2.17")
-	b, _ := WithContext(Context64).SetString("217")
-	c, _ := WithContext(Context128).SetString("-0.1")
-	d, _ := WithContext(Context{OperatingMode: GDA}).SetString("-0")
+	a, _ := decimal.WithContext(decimal.Context32).SetString("2.17")
+	b, _ := decimal.WithContext(decimal.Context64).SetString("217")
+	c, _ := decimal.WithContext(decimal.Context128).SetString("-0.1")
+	d, _ := decimal.WithContext(decimal.Context{OperatingMode: decimal.GDA}).SetString("-0")
 
 	fmt.Printf("A: %s\n", a.Quantize(3)) // 3 digits after radix
 	fmt.Printf("B: %s\n", b.Quantize(-2))


### PR DESCRIPTION
Small PR to make a more realistic example of how developers would actually use this library, this commit changes the package of the example tests from decimal to decimal_test, so that types in the package need to be imported.