### PR TITLE
Resolve Go 1.11 compile issue introduced in 2cd9f5e8c5b2

### DIFF
--- a/internal/arith/arith_1_11.go
+++ b/internal/arith/arith_1_11.go
@@ -16,8 +16,8 @@ func Add64(x, y uint64) (sum, carryOut uint64) {
 	return
 }
 
-func Sub64(x, y, borrow uint64) (diff, borrowOut uint64) {
-	yb := y + borrow
+func Sub64(x, y uint64) (diff, borrowOut uint64) {
+	yb := y
 	diff = x - yb
 	if diff > x || yb < y {
 		borrowOut = 1


### PR DESCRIPTION
The 1.11 API for Sub64() was accidentally copied from math/bits which doesn't
match the behavior expected by big_ctx.

Fixes #126 