### PR TITLE
Update to use Go Modules semver suffix /v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: go
 
 go:
-  - "1.11.x"
-  - "1.12.x"
+  - "1.13.x"
   - master
+
+env:
+  - GO111MODULE=on
 
 cache:
   directories:

--- a/README-fr.md
+++ b/README-fr.md
@@ -24,7 +24,7 @@ précision arbitrarie que mettre en œuvre la spécification
 ## Gestion des versions
 
 `decimal` utilise la gestion sémantique de la version. La version actuelle est
-3.3.1.
+4.0.0.
 
 `decimal` ne prend en charge que le deux versions plus récentes.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ the [General Decimal Arithmetic](http://speleotrove.com/decimal/) specification.
 
 ## Versioning
 
-`decimal` uses Semantic Versioning. The current version is 3.3.1.
+`decimal` uses Semantic Versioning. The current version is 4.0.0.
 
 `decimal` only explicitly supports the two most recent major Go 1.X versions.
 

--- a/benchmarks/mandelbrot_test.go
+++ b/benchmarks/mandelbrot_test.go
@@ -3,7 +3,7 @@ package benchmarks
 import (
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 const mbrotiters = 10000000

--- a/benchmarks/pi.go
+++ b/benchmarks/pi.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/apmckinlay/gsuneido/util/dnum"
 	"github.com/cockroachdb/apd"
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 	ssdec "github.com/shopspring/decimal"
 	"gopkg.in/inf.v0"
 )

--- a/benchmarks/pi_test.go
+++ b/benchmarks/pi_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/apmckinlay/gsuneido/util/dnum"
 	"github.com/cockroachdb/apd"
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 	ssdec "github.com/shopspring/decimal"
 	"gopkg.in/inf.v0"
 )

--- a/big.go
+++ b/big.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ericlagergren/decimal/internal/arith"
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 // Big is a floating-point, arbitrary-precision decimal.

--- a/big_ctx.go
+++ b/big_ctx.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/ericlagergren/decimal/internal/arith"
-	cst "github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	cst "github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 // Add sets z to x + y and returns z.

--- a/big_test.go
+++ b/big_test.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/test"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/test"
 )
 
 func TestBig_Abs(t *testing.T)        { test.Abs.Test(t) }

--- a/context.go
+++ b/context.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 // Precision and scale limits.

--- a/dectest/test.go
+++ b/dectest/test.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/math"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/math"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 func Test(t *testing.T, file string) {

--- a/dectest_test.go
+++ b/dectest_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ericlagergren/decimal/dectest"
+	"github.com/ericlagergren/decimal/v4/dectest"
 )
 
 // TestDecTests runs the dectest test suite.

--- a/example_calculator_test.go
+++ b/example_calculator_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func ExampleBig_reversePolishNotationCalculator() {

--- a/example_decimal_test.go
+++ b/example_decimal_test.go
@@ -3,7 +3,7 @@ package decimal_test
 import (
 	"fmt"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func ExampleBig_Format() {

--- a/fuzz/SetString/SetString.go
+++ b/fuzz/SetString/SetString.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func Fuzz(data []byte) int {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ericlagergren/decimal
+module github.com/ericlagergren/decimal/v4
 
 require (
 	github.com/apmckinlay/gsuneido v0.0.0-20190404155041-0b6cd442a18f

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/ericlagergren/decimal/v4
 require (
 	github.com/apmckinlay/gsuneido v0.0.0-20190404155041-0b6cd442a18f
 	github.com/cockroachdb/apd v1.1.0
-	github.com/lib/pq v1.0.0 // indirect
-	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
 	gopkg.in/inf.v0 v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/apmckinlay/gsuneido v0.0.0-20190404155041-0b6cd442a18f h1:WwxMm9boNua
 github.com/apmckinlay/gsuneido v0.0.0-20190404155041-0b6cd442a18f/go.mod h1:JU2DOj5Fc6rol0yaT79Csr47QR0vONGwJtBNGRD7jmc=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
-github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 h1:pntxY8Ary0t43dCZ5dqY4YTJCObLY1kIXl0uzMv+7DE=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/internal/arith/pow.go
+++ b/internal/arith/pow.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 const (

--- a/internal/arith/pow_test.go
+++ b/internal/arith/pow_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 func TestBigTen(t *testing.T) {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/math"
-	"github.com/ericlagergren/decimal/misc"
-	"github.com/ericlagergren/decimal/suite"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/math"
+	"github.com/ericlagergren/decimal/v4/misc"
+	"github.com/ericlagergren/decimal/v4/suite"
 )
 
 // Helper returns testing.T.Helper, if it exists.

--- a/math/arccosine.go
+++ b/math/arccosine.go
@@ -1,6 +1,6 @@
 package math
 
-import "github.com/ericlagergren/decimal"
+import "github.com/ericlagergren/decimal/v4"
 
 // Acos returns the arccosine, in radians, of x.
 //

--- a/math/arccosine_test.go
+++ b/math/arccosine_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestAcos(t *testing.T) {

--- a/math/arcsine.go
+++ b/math/arcsine.go
@@ -1,8 +1,8 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 // Asin returns the arcsine, in radians, of x.

--- a/math/arcsine_test.go
+++ b/math/arcsine_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestAsin(t *testing.T) {

--- a/math/arctangent.go
+++ b/math/arctangent.go
@@ -3,8 +3,8 @@ package math
 import (
 	stdMath "math"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 var sqrt3_3 = decimal.New(577350, 6) // sqrt(3) / 3

--- a/math/arctangent_test.go
+++ b/math/arctangent_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestAtan(t *testing.T) {

--- a/math/binary_spliting.go
+++ b/math/binary_spliting.go
@@ -1,8 +1,8 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/arith"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
 )
 
 // The binary splitting algorithm is made of four functions

--- a/math/common_test.go
+++ b/math/common_test.go
@@ -1,6 +1,6 @@
 package math
 
-import "github.com/ericlagergren/decimal"
+import "github.com/ericlagergren/decimal/v4"
 
 var gB *decimal.Big
 

--- a/math/const.go
+++ b/math/const.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math/bits"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 func newDecimal(s string) *decimal.Big {

--- a/math/const_test.go
+++ b/math/const_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 // Test whether Set or Scan is faster for setting constants.

--- a/math/continued_frac.go
+++ b/math/continued_frac.go
@@ -3,7 +3,7 @@ package math
 import (
 	"fmt"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 // Term is a specific term in a continued fraction. A and B correspond with the

--- a/math/cosine.go
+++ b/math/cosine.go
@@ -4,9 +4,9 @@ import (
 	stdMath "math"
 	"math/bits"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/arith"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 const maxInt = 1<<(bits.UintSize-1) - 1 // Also: uint64(int(^uint(0) << 1))

--- a/math/cosine_test.go
+++ b/math/cosine_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestCos(t *testing.T) {

--- a/math/example_cfphi_test.go
+++ b/math/example_cfphi_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	gmath "math"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/math"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/math"
 )
 
 var one = new(decimal.Big).SetUint64(1)

--- a/math/example_cftan_test.go
+++ b/math/example_cftan_test.go
@@ -3,8 +3,8 @@ package math_test
 import (
 	"fmt"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/math"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/math"
 )
 
 type tanGenerator struct {

--- a/math/exp.go
+++ b/math/exp.go
@@ -1,8 +1,8 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/arith"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
 )
 
 // Exp sets z to e ** x and returns z.

--- a/math/exp_test.go
+++ b/math/exp_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 var exp_X, _ = new(decimal.Big).SetString("123.456")

--- a/math/floor.go
+++ b/math/floor.go
@@ -1,8 +1,8 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 // Floor sets z to the greatest integer value less than or equal to x and returns

--- a/math/floor_test.go
+++ b/math/floor_test.go
@@ -3,7 +3,7 @@ package math
 import (
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestFloor(t *testing.T) {

--- a/math/log.go
+++ b/math/log.go
@@ -1,9 +1,9 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/arith"
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 // Log10 sets z to the common logarithm of x and returns z.

--- a/math/log_test.go
+++ b/math/log_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestIssue70(t *testing.T) {

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -3,9 +3,9 @@ package math_test
 import (
 	"testing"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/test"
-	"github.com/ericlagergren/decimal/math"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/test"
+	"github.com/ericlagergren/decimal/v4/math"
 )
 
 func TestExp(t *testing.T)   { test.Exp.Test(t) }

--- a/math/pi.go
+++ b/math/pi.go
@@ -3,7 +3,7 @@ package math
 import (
 	"math"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 var (

--- a/math/pi_test.go
+++ b/math/pi_test.go
@@ -2,9 +2,10 @@ package math
 
 import (
 	"fmt"
-	"github.com/ericlagergren/decimal"
 	"strconv"
 	"testing"
+
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestPiChudnovskyBrothers(t *testing.T) {

--- a/math/pow.go
+++ b/math/pow.go
@@ -1,8 +1,8 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 // TODO(eric): Pow(z, x, y, m *decimal.Big) *decimal.Big

--- a/math/sine.go
+++ b/math/sine.go
@@ -1,6 +1,6 @@
 package math
 
-import "github.com/ericlagergren/decimal"
+import "github.com/ericlagergren/decimal/v4"
 
 // Sin returns the sine, in radians, of x.
 //

--- a/math/sine_test.go
+++ b/math/sine_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestSin(t *testing.T) {

--- a/math/sqrt.go
+++ b/math/sqrt.go
@@ -1,6 +1,6 @@
 package math
 
-import "github.com/ericlagergren/decimal"
+import "github.com/ericlagergren/decimal/v4"
 
 // Hypot sets z to Sqrt(p*p + q*q) and returns z.
 func Hypot(z, p, q *decimal.Big) *decimal.Big {

--- a/math/sqrt_test.go
+++ b/math/sqrt_test.go
@@ -3,7 +3,7 @@ package math
 import (
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestDecimal_Hypot(t *testing.T) {

--- a/math/tangent.go
+++ b/math/tangent.go
@@ -1,9 +1,9 @@
 package math
 
 import (
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/arith"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 func prepTan(z, x *decimal.Big, ctx decimal.Context) (*decimal.Big, bool) {

--- a/math/tangent_test.go
+++ b/math/tangent_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 func TestTan(t *testing.T) {

--- a/math/util.go
+++ b/math/util.go
@@ -1,6 +1,6 @@
 package math
 
-import "github.com/ericlagergren/decimal"
+import "github.com/ericlagergren/decimal/v4"
 
 var (
 	negfour   = decimal.New(-4, 0)

--- a/misc/misc.go
+++ b/misc/misc.go
@@ -4,9 +4,9 @@ package misc
 import (
 	"math/big"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/arith"
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 var (

--- a/misc/misc_test.go
+++ b/misc/misc_test.go
@@ -3,9 +3,9 @@ package misc_test
 import (
 	"testing"
 
-	"github.com/ericlagergren/decimal"
-	"github.com/ericlagergren/decimal/internal/test"
-	"github.com/ericlagergren/decimal/misc"
+	"github.com/ericlagergren/decimal/v4"
+	"github.com/ericlagergren/decimal/v4/internal/test"
+	"github.com/ericlagergren/decimal/v4/misc"
 )
 
 func TestBig_NextMinus(t *testing.T) { test.NextMinus.Test(t) }

--- a/scan.go
+++ b/scan.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"unicode"
 
-	"github.com/ericlagergren/decimal/internal/arith"
-	"github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	"github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 func (z *Big) scan(r io.ByteScanner) error {

--- a/sql/postgres/decimal.go
+++ b/sql/postgres/decimal.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 const (

--- a/sql/postgres/decimal_test.go
+++ b/sql/postgres/decimal_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/v4"
 )
 
 var (

--- a/util.go
+++ b/util.go
@@ -3,8 +3,8 @@ package decimal
 import (
 	"math/big"
 
-	"github.com/ericlagergren/decimal/internal/arith"
-	cst "github.com/ericlagergren/decimal/internal/c"
+	"github.com/ericlagergren/decimal/v4/internal/arith"
+	cst "github.com/ericlagergren/decimal/v4/internal/c"
 )
 
 func (z *Big) norm() *Big {


### PR DESCRIPTION
I came across this issue when trying to update my own project that uses decimal. I was getting this error when trying to run `go get -u`:

```
$ go get -u github.com/ericlagergren/decimal
go: finding github.com/ericlagergren/decimal v3.3.1
go: errors parsing go.mod:
/blah/blah/blah/go.mod:7: require github.com/ericlagergren/decimal: version "v3.3.1" invalid: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3
```

I went spelunking through the issue tracker and came across [this comment](https://github.com/ericlagergren/decimal/issues/112#issuecomment-448312912), which makes sense to me as a strategy based on my own (possibly limited) understanding of the rather expansive list of caveats and processes for dealing with Go Modules. I'm not _completely_ sure I've done it right, but it's consistent with some of the example repos I looked at that use the `/v<n>` suffix.

It seems to work if I use the following `replace` directive in my project, then point my `go.mod` to v4.0.0: 

    replace github.com/ericlagergren/decimal/v4 => github.com/shabbyrobe/decimal/v4 v4.0.0

All the `-short` tests pass; I didn't wait around for the exhaustive float32 one but I'm happy to let it run if it's necessary. The repo will need to be tagged `v4.0.0` if you decide to merge it in order to work (I think).