### PR TITLE
format: fix `f` precision when exponent > 0

### DIFF
--- a/big.go
+++ b/big.go
@@ -629,7 +629,7 @@ func (x *Big) Format(s fmt.State, c rune) {
 		} else {
 			// %f's precision means "number of digits after the radix"
 			if x.exp > 0 {
-				f.prec += x.Precision()
+				f.prec += (x.exp + x.Precision())
 			} else {
 				if adj := x.exp + x.Precision(); adj > -f.prec {
 					f.prec += adj

--- a/big_test.go
+++ b/big_test.go
@@ -1,6 +1,7 @@
 package decimal_test
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"math/rand"
@@ -268,3 +269,14 @@ got   : %g
 }
 
 func isSpecial(f float64) bool { return math.IsInf(f, 0) || math.IsNaN(f) }
+
+func TestBig_Format(t *testing.T) {
+	x, _ := new(decimal.Big).SetString("200.0")
+	x.Reduce()
+
+	y := fmt.Sprintf("%.2f", x)
+
+	if y != "200.00" {
+		t.Fatalf("want 200.00 but had %s", y)
+	}
+}


### PR DESCRIPTION
👋Hi @ericlagergren — we've noticed a small edge case in the `f` format flag. It looks like this will be also fixed in https://github.com/ericlagergren/decimal/pull/144 but I figured I would report it anyway and propose a small change for the existing version if that one is still WIP.

<hr/>

Previously we would take only precision without also considering the
exponent, meaning you would have scenarios like 200 being formatted with
`%.2f` as just `200` as `x.exp` would be 2, and `x.Precision()` would be 1.