### PR TITLE
Fix Big.Float64() for large integers

### DIFF
--- a/big.go
+++ b/big.go
@@ -487,10 +487,16 @@ func (x *Big) Float64() (f float64, ok bool) {
 	case xc == 0:
 		ok = true
 	case x.IsInt():
-		if xc, ok := x.Int64(); ok {
+		if xc, convok := x.Int64(); convok {
 			f = float64(xc)
-		} else if xc, ok := x.Uint64(); ok {
+		} else if xc, convok := x.Uint64(); convok {
 			f = float64(xc)
+		} else {
+			// The compact value doesn't fit into an int, but it might
+			// still fit into a float. Try using strconv.ParseFloat.
+			f, _ = strconv.ParseFloat(x.String(), 64)
+			ok = !math.IsInf(f, 0) && !math.IsNaN(f)
+			break
 		}
 		ok = xc < maxMantissa || (xc&(xc-1)) == 0
 	case x.exp == 0:

--- a/issues_test.go
+++ b/issues_test.go
@@ -98,6 +98,17 @@ func TestIssue114(t *testing.T) {
 	}
 }
 
+func TestIssue158(t *testing.T) {
+	val := New(1, -300)
+	f, ok := val.Float64()
+	if !ok {
+		t.Fatal("expected true, got false")
+	}
+	if f != float64(1e300) {
+		t.Fatalf("expected 1e300, got %f", f)
+	}
+}
+
 func TestIssue129(t *testing.T) {
 	const ys = "3032043016321464119267109897502707536081241662295108925759281083" +
 		"5908762948729460330525095674778062760636202846843095908778429447" +


### PR DESCRIPTION
Previously, Big.Float64() would erroneously return 0 for large decimals
that were integer representable. For example, 1e300. This quantity,
instead of being Float64ified as 1e300, which is a valid float64, would
be returned as 0.

This bug is now corrected.