### PR TITLE
Make SetString return errors more consistently

### DIFF
--- a/big_test.go
+++ b/big_test.go
@@ -247,6 +247,23 @@ func TestBig_Scan(t *testing.T) {
 	// TODO(eric): write this test
 }
 
+func TestBig_ScanInvalid(t *testing.T) {
+	for i, test := range [...]struct {
+		v   string
+	}{
+		0: {"18e7b17e-4ead-4e27-bfd5-bb6d11261bb6"},
+		1: {"18e7b17e-4ead-4e27-bfd5"},
+		2: {"-18e7b"},
+		3: {"f"},
+		4: {"-f"},
+	} {
+		bd, ok := new(decimal.Big).SetString(test.v)
+		if ok {
+			t.Errorf("#%d: expected %s to fail parsing, but parsed %s", i, test.v, bd)
+		}
+	}
+}
+
 func TestBig_SetFloat64(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping testing all 32-bit floats in short mode")

--- a/scan.go
+++ b/scan.go
@@ -65,7 +65,7 @@ func (z *Big) scan(r io.ByteScanner) error {
 			z.form = qnan
 			z.Context.Conditions |= ConversionSyntax
 		}
-		return nil
+		return err
 	}
 
 	// Exponent
@@ -78,6 +78,7 @@ func (z *Big) scan(r io.ByteScanner) error {
 		case strconv.ErrSyntax:
 			z.form = qnan
 			z.Context.Conditions |= ConversionSyntax
+			return err
 		default:
 			return err
 		}
@@ -438,7 +439,7 @@ func (z *Big) scanExponent(r io.ByteScanner) (err error) {
 
 	if ch, err := r.ReadByte(); err != io.EOF {
 		if ch < '0' || ch > '9' {
-			return err
+			return strconv.ErrSyntax
 		}
 		if buf[0] == '-' {
 			return Underflow


### PR DESCRIPTION
Previously, SetString wouldn't consistently return syntax errors.
Sometimes, it would set a syntax error in the Context's traps and not
return an error; sometimes it would do both. Now, it always both sets a
syntax error in the traps and returns an error.

I think this only actually affected invalid exponents, because the similar
issue in mantissa scanning was code that couldn't have been reached due
to form scanning.