### PR TITLE
revert math.MaxInt -> arith.MaxInt

### DIFF
--- a/big_ctx.go
+++ b/big_ctx.go
@@ -769,7 +769,7 @@ func (c Context) prepCosine(z, x *Big) (*Big, int, bool) {
 		// 1+((v-1)/10) will be wildly incorrect for v == 0, but x/y = 0 iff
 		// x = 0 and y != 0. In this case, -2pi <= x >= 2pi, so we're fine.
 		prec, carry := bits.Add64(1+((uv-1)/10), uint64(c.Precision), 0)
-		if carry != 0 || prec > math.MaxInt {
+		if carry != 0 || prec > arith.MaxInt {
 			return nil, 0, false
 		}
 		pctx := Context{Precision: int(prec)}
@@ -3176,7 +3176,7 @@ func (c Context) prepTan(z, x *Big) (*Big, bool) {
 		// 1+((v-1)/10) will be widly incorrect for v == 0, but x/y = 0 iff
 		// x = 0 and y != 0. In this case, -2pi <= x >= 2pi, so we're fine.
 		prec, carry := bits.Add64(1+((uv-1)/10), uint64(c.Precision), 0)
-		if carry != 0 || prec > math.MaxInt {
+		if carry != 0 || prec > arith.MaxInt {
 			return nil, false
 		}
 		pctx := Context{Precision: int(prec)}

--- a/dectest/test.go
+++ b/dectest/test.go
@@ -3,13 +3,13 @@ package dectest
 import (
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"reflect"
 	"strconv"
 	"testing"
 
 	. "github.com/ericlagergren/decimal"
+	"github.com/ericlagergren/decimal/internal/arith"
 )
 
 func Test(t *testing.T, file string) {
@@ -182,7 +182,7 @@ func execute(t *testing.T, c *Case) {
 			check(t, z.Set(Min(x, y)), r, c, flags)
 		case OpQuantize:
 			v, _ := y.Int64()
-			if v > math.MaxInt {
+			if v > arith.MaxInt {
 				t.Logf("%s: int out of range: %d", c.ID, v)
 				return
 			}

--- a/internal/arith/arith.go
+++ b/internal/arith/arith.go
@@ -7,6 +7,11 @@ import (
 	"math/bits"
 )
 
+const (
+	intSize = 32 << (^uint(0) >> 63) // 32 or 64
+	MaxInt  = 1<<(intSize-1) - 1
+)
+
 // Words returns a little-endian slice of big.Words representing
 // the uint64.
 func Words(x uint64) []big.Word {

--- a/scan.go
+++ b/scan.go
@@ -309,7 +309,7 @@ func (z *Big) scanExponent(r io.ByteScanner) error {
 		r.UnreadByte()
 	}
 
-	max := uint64(math.MaxInt)
+	max := uint64(arith.MaxInt)
 	if neg {
 		max++ // -math.MinInt
 	}


### PR DESCRIPTION
Fixes #171

Signed-off-by: Eric Lagergren <eric@ericlagergren.com>