### PR TITLE
Correct curl option to download test cases from GDA

### DIFF
--- a/testdata/dectest/generate.bash
+++ b/testdata/dectest/generate.bash
@@ -2,6 +2,6 @@
 
 set -xeuo pipefail
 
-curl -sS http://speleotrove.com/decimal/dectest.zip >dectest.zip
+curl -sSOL http://speleotrove.com/decimal/dectest.zip
 unzip -o dectest.zip
 rm dectest.zip


### PR DESCRIPTION
Test caeses dectest.zip from GDA doesn't support http anymore.